### PR TITLE
Fixed missing decompress_map_ and added regression tests

### DIFF
--- a/include/pasta/block_tree/block_tree.hpp
+++ b/include/pasta/block_tree/block_tree.hpp
@@ -91,7 +91,7 @@ public:
       off = off % block_size;
       blk_pointer = lvl_rs.rank1(blk_pointer) * tau_ + child;
     }
-    return compressed_leaves_[blk_pointer * leaf_size + off];
+    return decompress_map_[compressed_leaves_[blk_pointer * leaf_size + off]];
   };
 
   int64_t select(input_type c, size_type j) {
@@ -401,12 +401,14 @@ public:
 
   void compress_leaves() {
     compress_map_.resize(256, 0);
+	decompress_map_.resize(256, 0);
     for (size_t i = 0; i < this->leaves_.size(); ++i) {
       compress_map_[this->leaves_[i]] = 1;
     }
     for (size_t i = 0, cur_val = 0; i < this->compress_map_.size(); ++i) {
       size_t tmp = compress_map_[i];
       compress_map_[i] = cur_val;
+	  decompress_map_[cur_val] = i;
       cur_val += tmp;
     }
 

--- a/tests/block_tree/block_tree_fp_test.cpp
+++ b/tests/block_tree/block_tree_fp_test.cpp
@@ -32,8 +32,10 @@ class BlockTreeFPTest : public ::testing::Test {
 protected:
 
   std::vector<uint8_t> text;
+  std::vector<uint8_t> gappy_alphabet_text;
 
   pasta::BlockTreeFP<uint8_t, int32_t>* bt;
+  pasta::BlockTreeFP<uint8_t, int32_t>* gappy_alphabet_bt;
   
   void SetUp() override {
 
@@ -43,16 +45,22 @@ protected:
 
     size_t const string_length = 100000;
     text.resize(string_length);
+	gappy_alphabet_text.resize(string_length);
     for (size_t i = 0; i < text.size(); ++i) {
       text[i] = dist(gen);
+	  gappy_alphabet_text[i] = 2*dist(gen);
     }
       
     bt = pasta::make_block_tree_fp<uint8_t, int32_t>(text, 2, 1);
     bt->add_rank_support();
+
+	gappy_alphabet_bt = pasta::make_block_tree_fp<uint8_t, int32_t>(gappy_alphabet_text, 2, 1);
+    gappy_alphabet_bt->add_rank_support();
   }
 
   void TearDown() override {
     delete bt;
+	delete gappy_alphabet_bt;
   }
 
 };
@@ -60,6 +68,12 @@ protected:
 TEST_F(BlockTreeFPTest, access) {
   for (size_t i = 0; i < text.size(); ++i) {
     ASSERT_EQ(bt->access(i), text[i]);
+  }
+}
+
+TEST_F(BlockTreeFPTest, access_gappy_alphabet) {
+  for (size_t i = 0; i < text.size(); ++i) {
+    ASSERT_EQ(gappy_alphabet_bt->access(i), gappy_alphabet_text[i]);
   }
 }
 

--- a/tests/block_tree/block_tree_lpf_parallel_test.cpp
+++ b/tests/block_tree/block_tree_lpf_parallel_test.cpp
@@ -32,8 +32,10 @@ class BlockTreeLPFParallelTest : public ::testing::Test {
 protected:
 
   std::vector<uint8_t> text;
+  std::vector<uint8_t> gappy_alphabet_text;
 
   pasta::BlockTreeLPF<uint8_t, int32_t>* bt;
+  pasta::BlockTreeLPF<uint8_t, int32_t>* gappy_alphabet_bt;
   
   void SetUp() override {
 
@@ -43,16 +45,21 @@ protected:
 
     size_t const string_length = 100000;
     text.resize(string_length);
+	gappy_alphabet_text.resize(string_length);
     for (size_t i = 0; i < text.size(); ++i) {
       text[i] = dist(gen);
+	  gappy_alphabet_text[i] = 2*dist(gen);
     }
 
     bt = pasta::make_block_tree_lpf_parallel<uint8_t, int32_t>(text, 2, 1, true, 4);
     bt->add_rank_support_omp(4);
+	gappy_alphabet_bt = pasta::make_block_tree_lpf_parallel<uint8_t, int32_t>(gappy_alphabet_text, 2, 1, true, 4);
+    gappy_alphabet_bt->add_rank_support_omp(4);
   }
 
   void TearDown() override {
     delete bt;
+	delete gappy_alphabet_bt;
   }
 
 };
@@ -60,6 +67,12 @@ protected:
 TEST_F(BlockTreeLPFParallelTest, access) {
   for (size_t i = 0; i < text.size(); ++i) {
     ASSERT_EQ(bt->access(i), text[i]);
+  }
+}
+
+TEST_F(BlockTreeLPFParallelTest, access_gappy_alphabet) {
+  for (size_t i = 0; i < text.size(); ++i) {
+    ASSERT_EQ(gappy_alphabet_bt->access(i), gappy_alphabet_text[i]);
   }
 }
 

--- a/tests/block_tree/block_tree_lpf_test.cpp
+++ b/tests/block_tree/block_tree_lpf_test.cpp
@@ -32,8 +32,10 @@ class BlockTreeLPFTest : public ::testing::Test {
 protected:
 
   std::vector<uint8_t> text;
+  std::vector<uint8_t> gappy_alphabet_text;
 
   pasta::BlockTreeLPF<uint8_t, int32_t>* bt;
+  pasta::BlockTreeLPF<uint8_t, int32_t>* gappy_alphabet_bt;
   
   void SetUp() override {
 
@@ -43,16 +45,21 @@ protected:
 
     size_t const string_length = 100000;
     text.resize(string_length);
+	gappy_alphabet_text.resize(string_length);
     for (size_t i = 0; i < text.size(); ++i) {
       text[i] = dist(gen);
+	  gappy_alphabet_text[i] = 2*dist(gen);
     }
 
     bt = pasta::make_block_tree_lpf<uint8_t, int32_t>(text, 2, 1, true);
     bt->add_rank_support();
+	gappy_alphabet_bt = pasta::make_block_tree_lpf<uint8_t, int32_t>(gappy_alphabet_text, 2, 1, true);
+    gappy_alphabet_bt->add_rank_support();
   }
 
   void TearDown() override {
     delete bt;
+	delete gappy_alphabet_bt;
   }
 
 };
@@ -60,6 +67,12 @@ protected:
 TEST_F(BlockTreeLPFTest, access) {
   for (size_t i = 0; i < text.size(); ++i) {
     ASSERT_EQ(bt->access(i), text[i]);
+  }
+}
+
+TEST_F(BlockTreeLPFTest, access_gappy_alphabet) {
+  for (size_t i = 0; i < text.size(); ++i) {
+    ASSERT_EQ(gappy_alphabet_bt->access(i), gappy_alphabet_text[i]);
   }
 }
 


### PR DESCRIPTION
The function `access()` now returns the original symbols of the text.

The function `access()` did only return the original value of the text, if and only if the alphabet had no gaps. Added the initialization of `decompress_map_` to `compress_leaves()` and its usage to `access()`.

Also added regression tests for gappy alphabets.